### PR TITLE
#5 Never use strings for secret values. Instead expect the name of an…

### DIFF
--- a/src/commands/inline-image-scan.yml
+++ b/src/commands/inline-image-scan.yml
@@ -6,7 +6,8 @@ parameters:
     type: string
   sysdig-secure-token:
     description: API token for Sysdig Scanning auth.
-    type: string
+    type: env_var_name
+    default: SYSDIG_SECURE_TOKEN
   sysdig-secure-url:
     description: 'Sysdig Secure URL (ex: "https://secure-sysdig.com").'
     type: string


### PR DESCRIPTION
#5 Never use  string type for storing a secret. Expect an environment variable. 
