### PR TITLE
fix: remove verbose mode from normal runs

### DIFF
--- a/src/commands/inline-image-scan.yml
+++ b/src/commands/inline-image-scan.yml
@@ -69,7 +69,7 @@ steps:
               -e SYSDIG_API_TOKEN=${<<parameters.sysdig-secure-token>>}
               <<#parameters.run-as-user>>-u <<parameters.run-as-user>><</parameters.run-as-user>>
               <<#parameters.extra-docker-parameters>><<parameters.extra-docker-parameters>><</parameters.extra-docker-parameters>>
-              <<parameters.secure-inline-scan-image>> -v
+              <<parameters.secure-inline-scan-image>>
               --sysdig-url <<parameters.sysdig-secure-url>>
               <<#parameters.sysdig-skip-tls>>--sysdig-skip-tls<</parameters.sysdig-skip-tls>>
               <<#parameters.extra-parameters>><<parameters.extra-parameters>><</parameters.extra-parameters>>
@@ -88,7 +88,7 @@ steps:
               <<#parameters.input-path>>-v <<parameters.input-path>>:/var/run/docker.sock<</parameters.input-path>>
               <<^parameters.input-path>>-v /var/run/docker.sock:/var/run/docker.sock<</parameters.input-path>>
               <<#parameters.extra-docker-parameters>><<parameters.extra-docker-parameters>><</parameters.extra-docker-parameters>>
-              <<parameters.secure-inline-scan-image>> -v
+              <<parameters.secure-inline-scan-image>>
               --sysdig-url <<parameters.sysdig-secure-url>>
               <<#parameters.sysdig-skip-tls>>--sysdig-skip-tls<</parameters.sysdig-skip-tls>>
               <<#parameters.extra-parameters>><<parameters.extra-parameters>><</parameters.extra-parameters>>


### PR DESCRIPTION
Verbose mode could be turned on using extra parameters.

At the moment, you get excessive logs which makes it hard to read the output.